### PR TITLE
Changed path from relative to eldenring.exe to FreeLockOnCamera.dll

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ Config/*
 mods
 SourceCode/x64
 Thumbnail.png
+/.vs

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,5 +1,5 @@
 ## FreeLockOnCamera
-###### Version: 0.2.1
+###### Version: 0.2.2
 
 This is a mod for Elden Ring v1.10.
 
@@ -12,7 +12,7 @@ https://www.youtube.com/watch?v=-FiB5SYhJls
 
 ### Installation
 0. Download and install [Elden Mod Loader](https://www.nexusmods.com/eldenring/mods/117) and [Anti-Cheat Toggler](https://www.nexusmods.com/eldenring/mods/90/). Disable anti-cheat if not done already.
-1. Download the file `FreeLockOnCamera.zip` from [Releases](https://github.com/SchuhBaum/FreeLockOnCamera/releases/tag/v0.2.1).
+1. Download the file `FreeLockOnCamera.zip` from [Releases](https://github.com/SchuhBaum/FreeLockOnCamera/releases/tag/v0.2.2).
 2. Extract its content in the folder `[Steam]\SteamApps\common\ELDEN RING\Game\`.
 3. Start the game as normal. Make sure that the in-game option `Launch Setting` is set to `Play Offline`.  
 
@@ -23,6 +23,9 @@ I am still new to Elden Ring modding. If you find bugs or side effects let me kn
 See the LICENSE-MIT.md file.
 
 ### Changelog
+v0.2.2:
+- Fixed `config.ini` having a hard-coded path (`Game\mods\FreeLockOnCamera\`) rather than pointing to the directory of `FreeLockOnCamera.dll`. (See: [issue](https://github.com/garyttierney/me3/issues/296))
+
 v0.2.1:
 - Added the parameter `additional_range` (default is zero). Increases the
   maximum lock-on range.

--- a/SourceCode/DllMain.cpp
+++ b/SourceCode/DllMain.cpp
@@ -73,9 +73,11 @@ void ReadAndLog_Config() {
     Log("ReadAndLog_Config");
     Log_Separator();
 
-    std::string configPath = GetModFolderPath()+"\\config.ini";
+    // modded;
+    std::string configPath = GetModFolderPath() + "\\config.ini"; // "absolute\\path\\to\\mod\\config.ini"
     Log("INI FILE PATH: ", configPath);
     INIFile config(configPath);
+    
     INIStructure ini;
 
     try {

--- a/SourceCode/DllMain.cpp
+++ b/SourceCode/DllMain.cpp
@@ -73,10 +73,9 @@ void ReadAndLog_Config() {
     Log("ReadAndLog_Config");
     Log_Separator();
 
-    //Log(GetModFolderPath()); //should be mods\FreeLockOnCamera
-    //Log(GetModFolderPath(false)); //should be the same as first
-    //Log(GetModFolderPath(true)); // should be a new thing
-    INIFile config(GetModFolderPath(true)+"\\config.ini"); //Extended GetModFolderPath() to accept an optional parameter, newPath.
+    std::string configPath = GetModFolderPath()+"\\config.ini";
+    Log("INI FILE PATH: ", configPath);
+    INIFile config(configPath);
     INIStructure ini;
 
     try {

--- a/SourceCode/DllMain.cpp
+++ b/SourceCode/DllMain.cpp
@@ -11,7 +11,7 @@ using namespace mINI;
 using namespace ModUtils;
 
 const std::string author = "SchuhBaum";
-const std::string version = "0.2.1";
+const std::string version = "0.2.2";
 
 // NOTE: Patches might also introduce cases where the searched array of bytes
 //       is not unique anymore. Check if matches are unique.

--- a/SourceCode/DllMain.cpp
+++ b/SourceCode/DllMain.cpp
@@ -72,7 +72,11 @@ void Log_Parameters() {
 void ReadAndLog_Config() {
     Log("ReadAndLog_Config");
     Log_Separator();
-    INIFile config(GetModFolderPath() + "\\config.ini");
+
+    //Log(GetModFolderPath()); //should be mods\FreeLockOnCamera
+    //Log(GetModFolderPath(false)); //should be the same as first
+    //Log(GetModFolderPath(true)); // should be a new thing
+    INIFile config(GetModFolderPath(true)+"\\config.ini"); //Extended GetModFolderPath() to accept an optional parameter, newPath.
     INIStructure ini;
 
     try {

--- a/SourceCode/FreeLockOnCamera.vcxproj
+++ b/SourceCode/FreeLockOnCamera.vcxproj
@@ -10,6 +10,12 @@
   <ItemGroup>
     <ClCompile Include="**/*.cpp"/>
     <!-- <Link Include="d3d11.lib;d3d12.lib;D3DCompiler.lib"/> -->
+	  <Content Include="**/RunMod.me3">
+		  <Link>RunMod.me3</Link>
+		  <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		  <SubType>Designer</SubType>
+		  <!-- just copying RunMod.me3 to the release folder for convenience. No more moving to game\mods\FreeLockOnCamera.dll, testing is now as simple as double clicking the profile (with me3 installed). -->
+	  </Content>
   </ItemGroup>
   
   <ItemDefinitionGroup>

--- a/SourceCode/FreeLockOnCamera.vcxproj
+++ b/SourceCode/FreeLockOnCamera.vcxproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup Label="Globals">
     <VCProjectVersion>17.0</VCProjectVersion>
-    <Version>0.2.1</Version>
+    <Version>0.2.2</Version>
     <RootNamespace>FreeLockOnCamera</RootNamespace>
   </PropertyGroup>
   

--- a/SourceCode/Include/ModUtils.h
+++ b/SourceCode/Include/ModUtils.h
@@ -100,7 +100,7 @@ namespace ModUtils
 
         if (removePath)
         {
-            moduleName = strrchr(lpFilename, '\\')
+            moduleName = strrchr(lpFilename, '\\');
             moduleName = moduleName.substr(1, moduleName.length());
         }
         else moduleName = lpFilename;

--- a/SourceCode/Include/ModUtils.h
+++ b/SourceCode/Include/ModUtils.h
@@ -83,8 +83,7 @@ namespace ModUtils
         std::chrono::system_clock::time_point lastPassedCheckTime;
     };
 
-    //new function. It's basically the first half of the old _GetModuleName(), but returns the string before any manipulation to it is done.
-    //This separation of pulling the raw data and processing it makes it more versatile.
+    //modded;
     static std::string _GetModulePath(bool mainProcessModule)
     {
         HMODULE module = NULL;
@@ -95,26 +94,29 @@ namespace ModUtils
             GetModuleHandleExA(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT, &dummyStaticVarToGetModuleHandle, &module);
         }
 
-        char lpFilename[MAX_PATH];
-        GetModuleFileNameA(module, lpFilename, MAX_PATH);
-        std::string modulePath = lpFilename;
+        char lpFilename[MAX_PATH]; // undefined
+        GetModuleFileNameA(module, lpFilename, MAX_PATH); // absolute\\path\\to\\mod.dll
+        std::string modulePath = lpFilename; // "absolute\\path\\to\\mod.dll" (as a string instead of char arr[])
 
-        return modulePath;
+        return modulePath; // Pulling the raw data and processing it has been separated.
     }
 
-    //Most of the logic of reflecting on its module is moved to _GetModulePath().
-    //Because the name is just a subset of its full path, and the old function simply did some string manipulation to it.
-    //The string manipulation remains here.
+    
     static std::string _GetModuleName(bool mainProcessModule)
     {
-        std::string moduleName;
-        moduleName = _GetModulePath(mainProcessModule);
-        moduleName = strrchr(moduleName.c_str(), '\\');
+        std::string moduleName; 
+        
+        //modded;
+        //First half of the old _GetModuleName() moved to _GetModulePath().
+        moduleName = _GetModulePath(mainProcessModule); // "absolute\\path\\to\\mod.dll" if mainProcessModule = false. No idea if = true.
+
+        //Second half unchanged
+        moduleName = strrchr(moduleName.c_str(), '\\'); // "mod.dll" (again if mainProcessModule = false, no idea if = true.)
         moduleName = moduleName.substr(1, moduleName.length());
 
         if (!mainProcessModule)
         {
-            moduleName.erase(moduleName.find(".dll"), moduleName.length());
+            moduleName.erase(moduleName.find(".dll"), moduleName.length()); // "mod"
         }
 
         return moduleName;
@@ -135,19 +137,17 @@ namespace ModUtils
         return currentModName;
     }
 
-    //ALTERED: use an absolute path, relative to .DLL rather than Eldenring.exe.
-    //Now uses _GetModulePath() instead of GetCurrentModName().
-    //The old one simply added "mods\\" to the start of GetCurrentModName().
-    //This one gets the path of the .dll and removes the ".dll" file extension.
-    //Old output:
-    //  "mods\\MODNAME"
-    //New output:
-    //  "DRIVELETTER:\\MODPACKDIRECTORY\\MODNAME"
+    
     static std::string GetModFolderPath()
     {
-        static std::string modFolderPath;
-        modFolderPath =  _GetModulePath(false);
-        modFolderPath.erase(modFolderPath.find(".dll"), modFolderPath.length());
+        // modded;
+        static std::string modFolderPath = "NULL"; // "NULL"
+        if (modFolderPath == "NULL") 
+        {
+            modFolderPath =  _GetModulePath(false); // "absolute\\path\\to\\mod.dll"
+            modFolderPath.erase(modFolderPath.find(".dll"), modFolderPath.length()); // "absolute\\path\\to\\mod"
+        }
+
         return modFolderPath;
     }
 

--- a/SourceCode/Include/ModUtils.h
+++ b/SourceCode/Include/ModUtils.h
@@ -141,7 +141,7 @@ namespace ModUtils
     static std::string GetModFolderPath()
     {
         // modded;
-        static std::string modFolderPath = "NULL"; // "NULL"
+        static std::string modFolderPath = "NULL"; // "NULL" (i.e. runs the below if statement on first call)
         if (modFolderPath == "NULL") 
         {
             modFolderPath =  _GetModulePath(false); // "absolute\\path\\to\\mod.dll"

--- a/SourceCode/Include/ModUtils.h
+++ b/SourceCode/Include/ModUtils.h
@@ -83,7 +83,8 @@ namespace ModUtils
         std::chrono::system_clock::time_point lastPassedCheckTime;
     };
 
-    static std::string _GetModuleName(bool mainProcessModule)
+    //ALTERED: ALLOWED KEEPING THE TRUE PATH BEFORE THE MODULE NAME
+    static std::string _GetModuleName(bool mainProcessModule, bool removePath = true)
     {
         HMODULE module = NULL;
 
@@ -94,10 +95,16 @@ namespace ModUtils
         }
 
         char lpFilename[MAX_PATH];
-        GetModuleFileNameA(module, lpFilename, sizeof(lpFilename));
-        std::string moduleName = strrchr(lpFilename, '\\');
-        moduleName = moduleName.substr(1, moduleName.length());
+        GetModuleFileNameA(module, lpFilename, MAX_PATH);
+        std::string moduleName;
 
+        if (removePath)
+        {
+            moduleName = strrchr(lpFilename, '\\')
+            moduleName = moduleName.substr(1, moduleName.length());
+        }
+        else moduleName = lpFilename;
+            
         if (!mainProcessModule)
         {
             moduleName.erase(moduleName.find(".dll"), moduleName.length());
@@ -121,9 +128,15 @@ namespace ModUtils
         return currentModName;
     }
 
-    static std::string GetModFolderPath()
+    //ALTERED: pass removePath (as !newPath) and don't add "mods\\" if using newPath.
+    //explanation: newPath is relative to the dll's location. The old path is relative to the .exe's location.
+    //newPath should work for everything. Old path works for mod loader, and most versions of mod engine, but NOT mod engine 3. 
+    static std::string GetModFolderPath(bool newPath = false)
     {
-        return std::string("mods\\" + GetCurrentModName());
+        static std::string modFolderPath;
+        if(newPath)     modFolderPath =  _GetModuleName(false, false);
+        else            modFolderPath = "mods\\" + GetCurrentModName();
+        return modFolderPath;
     }
 
     static void OpenModLogFile()

--- a/SourceCode/RunMod.me3
+++ b/SourceCode/RunMod.me3
@@ -1,0 +1,7 @@
+profileVersion = "v1"
+
+[[supports]]
+game = "eldenring"
+
+[[natives]]
+path = 'FreeLockOnCamera.dll'


### PR DESCRIPTION
Previous path:

```
Eldenring.exe
- Mods
-- FreeLockOnCamera
--- config.ini
```

New path:
```
FreeLockOnCamera.dll
- FreeLockOnCamera
-- config.ini
```

When FreeLockOnCamera.dll is located in \Mods, and these two will work identically. Most .dll injectors have this as a requirement.

[Mod engine 3](https://github.com/garyttierney/me3) however does not require a specific directory, and instead can inject .dlls from an arbitrary directory.

I have never worked in C++ before and this took way longer than I'd like to admit. Apologies for any mistakes.